### PR TITLE
Use correct version string format in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Setup Helm
 #### Install a specific version of helm binary on the runner.
 
-Acceptable values are latest or any semantic version string like 1.15.0. Use this action in workflow to define which version of helm will be used.
+Acceptable values are latest or any semantic version string like `v1.15.0`. Use this action in workflow to define which version of helm will be used.
 
 ```yaml
 - uses: azure/setup-helm@v1


### PR DESCRIPTION
If somebody uses `1.15.0` instead of `v1.15.0` the installation will fail, this adjusts instructions to be slightly clearer.