### PR TITLE
Update actions/toolkit versions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
          "version": "0.0.0",
          "license": "MIT",
          "dependencies": {
-            "@actions/core": "^1.9.1",
-            "@actions/exec": "^1.0.0",
-            "@actions/io": "^1.0.0",
-            "@actions/tool-cache": "1.1.2",
+            "@actions/core": "^1.10.0",
+            "@actions/exec": "^1.1.1",
+            "@actions/io": "^1.1.2",
+            "@actions/tool-cache": "2.0.1",
             "@octokit/auth-action": "^2.0.0",
             "@octokit/graphql": "^4.6.1",
             "semver": "^6.1.0"
@@ -27,9 +27,9 @@
          }
       },
       "node_modules/@actions/core": {
-         "version": "1.9.1",
-         "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-         "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+         "version": "1.10.0",
+         "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+         "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
          "dependencies": {
             "@actions/http-client": "^2.0.1",
             "uuid": "^8.3.2"
@@ -65,15 +65,15 @@
          "integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
       },
       "node_modules/@actions/tool-cache": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.1.2.tgz",
-         "integrity": "sha512-IJczPaZr02ECa3Lgws/TJEVco9tjOujiQSZbO3dHuXXjhd5vrUtfOgGwhmz3/f97L910OraPZ8SknofUk6RvOQ==",
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-2.0.1.tgz",
+         "integrity": "sha512-iPU+mNwrbA8jodY8eyo/0S/QqCKDajiR8OxWTnSk/SnYg0sj8Hp4QcUEVC1YFpHWXtrfbQrE13Jz4k4HXJQKcA==",
          "dependencies": {
-            "@actions/core": "^1.1.0",
-            "@actions/exec": "^1.0.1",
-            "@actions/io": "^1.0.1",
+            "@actions/core": "^1.2.6",
+            "@actions/exec": "^1.0.0",
+            "@actions/http-client": "^2.0.1",
+            "@actions/io": "^1.1.1",
             "semver": "^6.1.0",
-            "typed-rest-client": "^1.4.0",
             "uuid": "^3.3.2"
          }
       },
@@ -1600,18 +1600,6 @@
             "node": ">=0.10.0"
          }
       },
-      "node_modules/call-bind": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-         "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-         "dependencies": {
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.0.2"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
       "node_modules/callsites": {
          "version": "3.1.0",
          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2541,7 +2529,8 @@
       "node_modules/function-bind": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-         "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+         "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+         "dev": true
       },
       "node_modules/gensync": {
          "version": "1.0.0-beta.2",
@@ -2559,19 +2548,6 @@
          "dev": true,
          "engines": {
             "node": "6.* || 8.* || >= 10.*"
-         }
-      },
-      "node_modules/get-intrinsic": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-         "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
-         "dependencies": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.3"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/get-package-type": {
@@ -2653,6 +2629,7 @@
          "version": "1.0.3",
          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+         "dev": true,
          "dependencies": {
             "function-bind": "^1.1.1"
          },
@@ -2667,17 +2644,6 @@
          "dev": true,
          "engines": {
             "node": ">=8"
-         }
-      },
-      "node_modules/has-symbols": {
-         "version": "1.0.3",
-         "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-         "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/has-value": {
@@ -4281,14 +4247,6 @@
             "node": ">=0.10.0"
          }
       },
-      "node_modules/object-inspect": {
-         "version": "1.12.2",
-         "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-         "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
       "node_modules/object-visit": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -4584,20 +4542,6 @@
          "dev": true,
          "engines": {
             "node": ">=6"
-         }
-      },
-      "node_modules/qs": {
-         "version": "6.11.0",
-         "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-         "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-         "dependencies": {
-            "side-channel": "^1.0.4"
-         },
-         "engines": {
-            "node": ">=0.6"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/react-is": {
@@ -5202,19 +5146,6 @@
          "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
          "dev": true,
          "optional": true
-      },
-      "node_modules/side-channel": {
-         "version": "1.0.4",
-         "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-         "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-         "dependencies": {
-            "call-bind": "^1.0.0",
-            "get-intrinsic": "^1.0.2",
-            "object-inspect": "^1.9.0"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
       },
       "node_modules/signal-exit": {
          "version": "3.0.7",
@@ -5953,16 +5884,6 @@
             "url": "https://github.com/sponsors/sindresorhus"
          }
       },
-      "node_modules/typed-rest-client": {
-         "version": "1.8.9",
-         "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
-         "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
-         "dependencies": {
-            "qs": "^6.9.1",
-            "tunnel": "0.0.6",
-            "underscore": "^1.12.1"
-         }
-      },
       "node_modules/typedarray-to-buffer": {
          "version": "3.1.5",
          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -5984,11 +5905,6 @@
          "engines": {
             "node": ">=4.2.0"
          }
-      },
-      "node_modules/underscore": {
-         "version": "1.13.4",
-         "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-         "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
       },
       "node_modules/union-value": {
          "version": "1.0.1",
@@ -6381,9 +6297,9 @@
    },
    "dependencies": {
       "@actions/core": {
-         "version": "1.9.1",
-         "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-         "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+         "version": "1.10.0",
+         "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+         "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
          "requires": {
             "@actions/http-client": "^2.0.1",
             "uuid": "^8.3.2"
@@ -6418,15 +6334,15 @@
          "integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
       },
       "@actions/tool-cache": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.1.2.tgz",
-         "integrity": "sha512-IJczPaZr02ECa3Lgws/TJEVco9tjOujiQSZbO3dHuXXjhd5vrUtfOgGwhmz3/f97L910OraPZ8SknofUk6RvOQ==",
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-2.0.1.tgz",
+         "integrity": "sha512-iPU+mNwrbA8jodY8eyo/0S/QqCKDajiR8OxWTnSk/SnYg0sj8Hp4QcUEVC1YFpHWXtrfbQrE13Jz4k4HXJQKcA==",
          "requires": {
-            "@actions/core": "^1.1.0",
-            "@actions/exec": "^1.0.1",
-            "@actions/io": "^1.0.1",
+            "@actions/core": "^1.2.6",
+            "@actions/exec": "^1.0.0",
+            "@actions/http-client": "^2.0.1",
+            "@actions/io": "^1.1.1",
             "semver": "^6.1.0",
-            "typed-rest-client": "^1.4.0",
             "uuid": "^3.3.2"
          }
       },
@@ -7650,15 +7566,6 @@
             "unset-value": "^1.0.0"
          }
       },
-      "call-bind": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-         "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-         "requires": {
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.0.2"
-         }
-      },
       "callsites": {
          "version": "3.1.0",
          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -8381,7 +8288,8 @@
       "function-bind": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-         "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+         "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+         "dev": true
       },
       "gensync": {
          "version": "1.0.0-beta.2",
@@ -8394,16 +8302,6 @@
          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
          "dev": true
-      },
-      "get-intrinsic": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-         "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
-         "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.3"
-         }
       },
       "get-package-type": {
          "version": "0.1.0",
@@ -8463,6 +8361,7 @@
          "version": "1.0.3",
          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+         "dev": true,
          "requires": {
             "function-bind": "^1.1.1"
          }
@@ -8472,11 +8371,6 @@
          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
          "dev": true
-      },
-      "has-symbols": {
-         "version": "1.0.3",
-         "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-         "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
       },
       "has-value": {
          "version": "1.0.0",
@@ -9730,11 +9624,6 @@
             }
          }
       },
-      "object-inspect": {
-         "version": "1.12.2",
-         "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-         "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
-      },
       "object-visit": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -9950,14 +9839,6 @@
          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
          "dev": true
-      },
-      "qs": {
-         "version": "6.11.0",
-         "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-         "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-         "requires": {
-            "side-channel": "^1.0.4"
-         }
       },
       "react-is": {
          "version": "17.0.2",
@@ -10432,16 +10313,6 @@
          "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
          "dev": true,
          "optional": true
-      },
-      "side-channel": {
-         "version": "1.0.4",
-         "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-         "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-         "requires": {
-            "call-bind": "^1.0.0",
-            "get-intrinsic": "^1.0.2",
-            "object-inspect": "^1.9.0"
-         }
       },
       "signal-exit": {
          "version": "3.0.7",
@@ -11026,16 +10897,6 @@
          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
          "dev": true
       },
-      "typed-rest-client": {
-         "version": "1.8.9",
-         "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
-         "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
-         "requires": {
-            "qs": "^6.9.1",
-            "tunnel": "0.0.6",
-            "underscore": "^1.12.1"
-         }
-      },
       "typedarray-to-buffer": {
          "version": "3.1.5",
          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -11050,11 +10911,6 @@
          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
          "dev": true
-      },
-      "underscore": {
-         "version": "1.13.4",
-         "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-         "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
       },
       "union-value": {
          "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
    "author": "Anumita Shenoy",
    "license": "MIT",
    "dependencies": {
-      "@actions/core": "^1.9.1",
-      "@actions/exec": "^1.0.0",
-      "@actions/io": "^1.0.0",
-      "@actions/tool-cache": "1.1.2",
+      "@actions/core": "^1.10.0",
+      "@actions/exec": "^1.1.1",
+      "@actions/io": "^1.1.2",
+      "@actions/tool-cache": "2.0.1",
       "@octokit/auth-action": "^2.0.0",
       "@octokit/graphql": "^4.6.1",
       "semver": "^6.1.0"


### PR DESCRIPTION
Update actions/core to version 1.10.0 to avoid the warning:
```
The `set-output` command is deprecated and will be disabled soon.
Please upgrade to using Environment Files. For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```