### PR TITLE
refactor: cleanup GH gql query

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -71,10 +71,12 @@ export async function getLatestHelmVersion(): Promise<string> {
             }
          `
       )
-      const releases: string[] = repository.releases.nodes.map(
-         (node: {tagName: string}) => node.tagName
-      )
-      const latestValidRelease = releases.find((tag) => isValidVersion(tag))
+      const latestValidRelease: string = repository.releases.nodes
+         .find(
+            ({tagName, isLatest, isDraft, isPreRelease}) => 
+                isValidVersion(tagName) && isLatest && !isDraft && !isPreRelease
+          )?.tagName
+
       if (latestValidRelease) return latestValidRelease
    } catch (err) {
       core.warning(

--- a/src/run.ts
+++ b/src/run.ts
@@ -62,6 +62,9 @@ export async function getLatestHelmVersion(): Promise<string> {
                   releases(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {
                      nodes {
                         tagName
+                        isLatest
+                        isDraft
+                        isPrerelease
                      }
                   }
                }

--- a/src/run.ts
+++ b/src/run.ts
@@ -59,7 +59,7 @@ export async function getLatestHelmVersion(): Promise<string> {
          `
             {
                repository(name: "helm", owner: "helm") {
-                  releases(last: 100) {
+                  releases(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {
                      nodes {
                         tagName
                      }
@@ -68,9 +68,9 @@ export async function getLatestHelmVersion(): Promise<string> {
             }
          `
       )
-      const releases: string[] = repository.releases.nodes
-         .reverse()
-         .map((node: {tagName: string}) => node.tagName)
+      const releases: string[] = repository.releases.nodes.map(
+         (node: {tagName: string}) => node.tagName
+      )
       const latestValidRelease = releases.find((tag) => isValidVersion(tag))
       if (latestValidRelease) return latestValidRelease
    } catch (err) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -71,12 +71,11 @@ export async function getLatestHelmVersion(): Promise<string> {
             }
          `
       )
-      const latestValidRelease: string = repository.releases.nodes
-         .find(
-            ({tagName, isLatest, isDraft, isPreRelease}) => 
-                isValidVersion(tagName) && isLatest && !isDraft && !isPreRelease
-          )?.tagName
-
+    const latestValidRelease: string = repository.releases.nodes.find(
+      ({ tagName, isLatest, isDraft, isPreRelease }) =>
+        isValidVersion(tagName) && isLatest && !isDraft && !isPreRelease
+    )?.tagName;
+    
       if (latestValidRelease) return latestValidRelease
    } catch (err) {
       core.warning(

--- a/src/run.ts
+++ b/src/run.ts
@@ -71,11 +71,11 @@ export async function getLatestHelmVersion(): Promise<string> {
             }
          `
       )
-    const latestValidRelease: string = repository.releases.nodes.find(
-      ({ tagName, isLatest, isDraft, isPreRelease }) =>
-        isValidVersion(tagName) && isLatest && !isDraft && !isPreRelease
-    )?.tagName;
-    
+      const latestValidRelease: string = repository.releases.nodes.find(
+         ({tagName, isLatest, isDraft, isPreRelease}) =>
+            isValidVersion(tagName) && isLatest && !isDraft && !isPreRelease
+      )?.tagName
+
       if (latestValidRelease) return latestValidRelease
    } catch (err) {
       core.warning(


### PR DESCRIPTION
This updates the graphql query used to fetch releases by:
- returning only the first 10
- ordering them in reverse by created_at

This is better because it does not rely on the default ordering by the GitHub graphql API.

Co-authored-by: Pieter Van der Haegen @vdhpieter

## Testing Plan

I ran this query through the GitHub API explorer [here](https://docs.github.com/en/graphql/overview/explorer): 

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/3806031/197817202-f06e92c3-53a0-4ec2-86d7-c752b620490e.png">

