### PR TITLE
minor nit and GH action version updates

### DIFF
--- a/.github/workflows/defaultLabels.yml
+++ b/.github/workflows/defaultLabels.yml
@@ -13,7 +13,7 @@ jobs:
 
       # Steps represent a sequence of tasks that will be executed as part of the job
       steps:
-         - uses: actions/stale@v3
+         - uses: actions/stale@v6
            name: Setting issue as idle
            with:
               repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
               operations-per-run: 100
               exempt-issue-labels: 'backlog'
 
-         - uses: actions/stale@v3
+         - uses: actions/stale@v6
            name: Setting PR as idle
            with:
               repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       steps:
          - name: Check out repository
-           uses: actions/checkout@v2
+           uses: actions/checkout@v3
          - name: npm install and build
            id: action-npm-build
            run: |

--- a/.github/workflows/prettify-code.yml
+++ b/.github/workflows/prettify-code.yml
@@ -10,7 +10,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
          - name: Checkout Repository
-           uses: actions/checkout@v2
+           uses: actions/checkout@v3
 
          - name: Enforce Prettier
            uses: actionsx/prettier@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
    build: # make sure build/ci works properly
       runs-on: ubuntu-latest
       steps:
-         - uses: actions/checkout@v1
+         - uses: actions/checkout@v3
 
          - name: Run L0 tests.
            run: |

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -23,19 +23,19 @@ describe('run.ts', () => {
    test('getHelmDownloadURL() - return the URL to download helm for Linux', () => {
       jest.spyOn(os, 'type').mockReturnValue('Linux')
       jest.spyOn(os, 'arch').mockReturnValueOnce('unknown')
-      const kubectlLinuxUrl = 'https://get.helm.sh/helm-v3.8.0-linux-amd64.zip'
+      const helmLinuxUrl = 'https://get.helm.sh/helm-v3.8.0-linux-amd64.zip'
 
-      expect(run.getHelmDownloadURL('v3.8.0')).toBe(kubectlLinuxUrl)
+      expect(run.getHelmDownloadURL('v3.8.0')).toBe(helmLinuxUrl)
       expect(os.type).toBeCalled()
       expect(os.arch).toBeCalled()
 
       // arm64
       jest.spyOn(os, 'type').mockReturnValue('Linux')
       jest.spyOn(os, 'arch').mockReturnValueOnce('arm64')
-      const kubectlLinuxArm64Url =
+      const helmLinuxArm64Url =
          'https://get.helm.sh/helm-v3.8.0-linux-arm64.zip'
 
-      expect(run.getHelmDownloadURL('v3.8.0')).toBe(kubectlLinuxArm64Url)
+      expect(run.getHelmDownloadURL('v3.8.0')).toBe(helmLinuxArm64Url)
       expect(os.type).toBeCalled()
       expect(os.arch).toBeCalled()
    })
@@ -43,20 +43,19 @@ describe('run.ts', () => {
    test('getHelmDownloadURL() - return the URL to download helm for Darwin', () => {
       jest.spyOn(os, 'type').mockReturnValue('Darwin')
       jest.spyOn(os, 'arch').mockReturnValueOnce('unknown')
-      const kubectlDarwinUrl =
-         'https://get.helm.sh/helm-v3.8.0-darwin-amd64.zip'
+      const helmDarwinUrl = 'https://get.helm.sh/helm-v3.8.0-darwin-amd64.zip'
 
-      expect(run.getHelmDownloadURL('v3.8.0')).toBe(kubectlDarwinUrl)
+      expect(run.getHelmDownloadURL('v3.8.0')).toBe(helmDarwinUrl)
       expect(os.type).toBeCalled()
       expect(os.arch).toBeCalled()
 
       // arm64
       jest.spyOn(os, 'type').mockReturnValue('Darwin')
       jest.spyOn(os, 'arch').mockReturnValueOnce('arm64')
-      const kubectlDarwinArm64Url =
+      const helmDarwinArm64Url =
          'https://get.helm.sh/helm-v3.8.0-darwin-arm64.zip'
 
-      expect(run.getHelmDownloadURL('v3.8.0')).toBe(kubectlDarwinArm64Url)
+      expect(run.getHelmDownloadURL('v3.8.0')).toBe(helmDarwinArm64Url)
       expect(os.type).toBeCalled()
       expect(os.arch).toBeCalled()
    })
@@ -68,14 +67,13 @@ describe('run.ts', () => {
    test('getHelmDownloadURL() - return the URL to download helm for Windows', () => {
       jest.spyOn(os, 'type').mockReturnValue('Windows_NT')
 
-      const kubectlWindowsUrl =
-         'https://get.helm.sh/helm-v3.8.0-windows-amd64.zip'
-      expect(run.getHelmDownloadURL('v3.8.0')).toBe(kubectlWindowsUrl)
+      const helmWindowsUrl = 'https://get.helm.sh/helm-v3.8.0-windows-amd64.zip'
+      expect(run.getHelmDownloadURL('v3.8.0')).toBe(helmWindowsUrl)
       expect(os.type).toBeCalled()
    })
 
    test('getLatestHelmVersion() - return the stable version of HELM since its not authenticated', async () => {
-      expect(await run.getLatestHelmVersion()).toBe('v3.9.0')
+      expect(await run.getLatestHelmVersion()).toBe('v3.10.2')
    })
 
    test('walkSync() - return path to the all files matching fileToFind in dir', () => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -11,10 +11,9 @@ import * as toolCache from '@actions/tool-cache'
 import * as core from '@actions/core'
 import {graphql} from '@octokit/graphql'
 import {createActionAuth} from '@octokit/auth-action'
-import {create} from 'domain'
 
 const helmToolName = 'helm'
-const stableHelmVersion = 'v3.9.0'
+const stableHelmVersion = 'v3.10.2'
 
 export async function run() {
    let version = core.getInput('version', {required: true})


### PR DESCRIPTION
- Update helm to 3.10.2 
- Rename variables in test from kubectl to helm 
- Update Github Actions to use latest version of checkout and other actions 