### PR TITLE
chore: use github.token as default input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,7 @@ inputs:
    token:
       description: GitHub token. Required only if 'version' == 'latest'
       required: false
+      default: "${{ github.token }}"
 outputs:
    helm-path:
       description: 'Path to the cached helm binary'


### PR DESCRIPTION
Add `github.token` as default token input.

Currently if no token nor version is specified the action will return - as known - a warning:

> Warning: Error while fetching latest Helm release: Error: [@octokit/auth-action] `GITHUB_TOKEN` variable is not set. It must be set on either `env:` or `with:`. See https://github.com/octokit/auth-action.js#createactionauth. Using default version v3.9.0

This can be resolved if the default token will automatically be specified.
With this change the workflow step to setup-helm can be one single line.