### PR TITLE
v4 release and required workflow updates

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,14 +1,18 @@
-name: Create release PR
+name: release Project
 
 on:
+   push:
+      branches:
+         - main
+      paths:
+         - CHANGELOG.md
    workflow_dispatch:
-      inputs:
-         release:
-            description: 'Define release version (ex: v1, v2, v3)'
-            required: true
 
 jobs:
-   release-pr:
-      uses: OliverMKing/javascript-release-workflow/.github/workflows/release-pr.yml@main
+   release:
+      permissions:
+         actions: read
+         contents: write
+      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@e4a1a0385530d6861c9a9b7262058ad33b10c769
       with:
-         release: ${{ github.event.inputs.release }}
+         changelogPath: ./CHANGELOG.md

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,6 +13,6 @@ jobs:
       permissions:
          actions: read
          contents: write
-      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@e4a1a0385530d6861c9a9b7262058ad33b10c769
+      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@074d812926f43e21038fb170ba2f4bc4e8111503
       with:
          changelogPath: ./CHANGELOG.md

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,4 +1,4 @@
-name: release Project
+name: Release Project
 
 on:
    push:
@@ -13,6 +13,6 @@ jobs:
       permissions:
          actions: read
          contents: write
-      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@074d812926f43e21038fb170ba2f4bc4e8111503
+      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@a705b2ab6a3ee889f2b0d925ad0bd2f9eb733ce6
       with:
          changelogPath: ./CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+## [4.0.0] - 2024-02-12
+- #121 update to node20 as node16 is deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change Log
 
 ## [4.0.0] - 2024-02-12
-- #121 update to node20 as node16 is deprecated
+
+-  #121 update to node20 as node16 is deprecated

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
    },
    "main": "lib/index.js",
    "scripts": {
+      "prebuild":"npm i ncc",
       "build": "ncc build src/run.ts -o lib",
       "test": "jest",
       "test-coverage": "jest --coverage",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
    },
    "main": "lib/index.js",
    "scripts": {
-      "prebuild":"npm i ncc",
+      "prebuild": "npm i ncc",
       "build": "ncc build src/run.ts -o lib",
       "test": "jest",
       "test-coverage": "jest --coverage",


### PR DESCRIPTION
cut the v4 release via adding corresponding changelog entry

update to use prebuild script for ncc install

update to Azure release workflow

add required workflow job permissions block

validated on test fork https://github.com/davidgamero/setup-helm/actions/runs/7879164577