### PR TITLE
Fix action version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install a specific version of helm binary on the runner.
 Acceptable values are latest or any semantic version string like v3.5.0 Use this action in workflow to define which version of helm will be used. v2+ of this action only support Helm3.
 
 ```yaml
-- uses: azure/setup-helm@v4
+- uses: azure/setup-helm@v4.0.0
   with:
      version: '<version>' # default is latest (stable)
      token: ${{ secrets.GITHUB_TOKEN }} # only needed if version is 'latest'


### PR DESCRIPTION
`v4` is not a valid tag, `v4.0.0` is.

See https://github.com/Azure/setup-helm/tags