### PR TITLE
Simply fetch latest version from the dedicated file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,9 @@ inputs:
       required: true
       default: 'latest'
    token:
-      description: GitHub token. Required only if 'version' == 'latest'
+      description: GitHub token. Used to be reuired to fetch the latest version
       required: false
+      deprecationMessage: 'GitHub token is no longer required'
       default: '${{ github.token }}'
    downloadBaseURL:
       description: 'Set the download base URL'

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
       required: true
       default: 'latest'
    token:
-      description: GitHub token. Used to be reuired to fetch the latest version
+      description: GitHub token. Used to be required to fetch the latest version
       required: false
       deprecationMessage: 'GitHub token is no longer required'
       default: '${{ github.token }}'

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -87,7 +87,12 @@ describe('run.ts', () => {
    })
 
    test('getLatestHelmVersion() - return the latest version of HELM', async () => {
-      expect(await run.getLatestHelmVersion()).toBe('v3.14.2')
+      const res = {
+         status: 200,
+         text: async () => 'v9.99.999'
+      } as Response
+      global.fetch = jest.fn().mockReturnValue(res)
+      expect(await run.getLatestHelmVersion()).toBe('v9.99.999')
    })
 
    test('getLatestHelmVersion() - return the stable version of HELM when simulating a network error', async () => {

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -86,7 +86,13 @@ describe('run.ts', () => {
       expect(os.type).toHaveBeenCalled()
    })
 
-   test('getLatestHelmVersion() - return the stable version of HELM since its not authenticated', async () => {
+   test('getLatestHelmVersion() - return the latest version of HELM', async () => {
+      expect(await run.getLatestHelmVersion()).toBe('v3.14.2')
+   })
+
+   test('getLatestHelmVersion() - return the stable version of HELM when simulating a network error', async () => {
+      const errorMessage: string = "Network Error";
+      global.fetch = jest.fn().mockRejectedValueOnce(new Error(errorMessage));
       expect(await run.getLatestHelmVersion()).toBe('v3.13.3')
    })
 

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -91,8 +91,8 @@ describe('run.ts', () => {
    })
 
    test('getLatestHelmVersion() - return the stable version of HELM when simulating a network error', async () => {
-      const errorMessage: string = "Network Error";
-      global.fetch = jest.fn().mockRejectedValueOnce(new Error(errorMessage));
+      const errorMessage: string = 'Network Error'
+      global.fetch = jest.fn().mockRejectedValueOnce(new Error(errorMessage))
       expect(await run.getLatestHelmVersion()).toBe('v3.13.3')
    })
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,7 +9,6 @@ import * as fs from 'fs'
 
 import * as toolCache from '@actions/tool-cache'
 import * as core from '@actions/core'
-import {Octokit} from '@octokit/action'
 
 const helmToolName = 'helm'
 const stableHelmVersion = 'v3.13.3'
@@ -51,38 +50,15 @@ export function getValidVersion(version: string): string {
 // Gets the latest helm version or returns a default stable if getting latest fails
 export async function getLatestHelmVersion(): Promise<string> {
    try {
-      const octokit = new Octokit()
-      const response = await octokit.rest.repos.listReleases({
-         owner: 'helm',
-         repo: 'helm',
-         per_page: 100,
-         order: 'desc',
-         sort: 'created'
-      })
-
-      const releases = response.data
-      const latestValidRelease: string = releases.find(
-         ({tag_name, draft, prerelease}) =>
-            isValidVersion(tag_name) && !draft && !prerelease
-      )?.tag_name
-
-      if (latestValidRelease) return latestValidRelease
+      const response = await fetch('https://get.helm.sh/helm-latest-version')
+      const release = (await response.text()).trim()
+      return release
    } catch (err) {
       core.warning(
          `Error while fetching latest Helm release: ${err.toString()}. Using default version ${stableHelmVersion}`
       )
       return stableHelmVersion
    }
-
-   core.warning(
-      `Could not find valid release. Using default version ${stableHelmVersion}`
-   )
-   return stableHelmVersion
-}
-
-// isValidVersion checks if verison is a stable release
-function isValidVersion(version: string): boolean {
-   return version.indexOf('rc') == -1
 }
 
 export function getExecutableExtension(): string {


### PR DESCRIPTION
It gets updated as part of the helm release workflow:
https://github.com/helm/helm/blob/c5698e5e51949c4ab86a22c5566fac20e13d6f73/.github/workflows/release.yml#L49

This means the github token is no longer required, making it much nicer
for composite actions wanting to leverage this one.