### PR TITLE
feat: log when restoring from cache

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -91,7 +91,7 @@ export async function downloadHelm(
       core.info(`Restoring '${version}' from cache`)
    } else {
       core.info(`Downloading '${version}' from '${baseURL}'`)
-      let helmDownloadPath;
+      let helmDownloadPath
       try {
          helmDownloadPath = await toolCache.downloadTool(
             getHelmDownloadURL(baseURL, version)

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,4 @@
 // Copyright (c) Microsoft Corporation.
-// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 import * as os from 'os'
@@ -26,7 +25,7 @@ export async function run() {
 
    const downloadBaseURL = core.getInput('downloadBaseURL', {required: false})
 
-   core.startGroup(`Downloading ${version}`)
+   core.startGroup(`Installing ${version}`)
    const cachedPath = await downloadHelm(downloadBaseURL, version)
    core.endGroup()
 
@@ -88,8 +87,11 @@ export async function downloadHelm(
    version: string
 ): Promise<string> {
    let cachedToolpath = toolCache.find(helmToolName, version)
-   if (!cachedToolpath) {
-      let helmDownloadPath
+   if (cachedToolpath) {
+      core.info(`Restoring '${version}' from cache`)
+   } else {
+      core.info(`Downloading '${version}' from '${baseURL}'`)
+      let helmDownloadPath;
       try {
          helmDownloadPath = await toolCache.downloadTool(
             getHelmDownloadURL(baseURL, version)


### PR DESCRIPTION
I recently switched one of our Actions to use `Azure/setup-helm`, thanks for sharing this. I wanted to understand from the action logs whether or not the cache was being used correctly, but that information wasn't in the logs.

This PR:
- updates the logs to distinguish between cache hits and cache misses
- removes a duplicate copyright line