### PR TITLE
Pinning Action Dependencies for Security and Reliability

### DIFF
--- a/.github/workflows/defaultLabels.yml
+++ b/.github/workflows/defaultLabels.yml
@@ -13,7 +13,7 @@ jobs:
 
       # Steps represent a sequence of tasks that will be executed as part of the job
       steps:
-         - uses: actions/stale@v9
+         - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 #v9.1.0
            name: Setting issue as idle
            with:
               repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
               operations-per-run: 100
               exempt-issue-labels: 'backlog'
 
-         - uses: actions/stale@v9
+         - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 #v9.1.0
            name: Setting PR as idle
            with:
               repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       steps:
          - name: Check out repository
-           uses: actions/checkout@v4
+           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
          - name: npm install and build
            id: action-npm-build
            run: |

--- a/.github/workflows/prettify-code.yml
+++ b/.github/workflows/prettify-code.yml
@@ -13,6 +13,6 @@ jobs:
            uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
          - name: Enforce Prettier
-           uses: actionsx/prettier@v3
+           uses: actionsx/prettier@3d9f7c3fa44c9cb819e68292a328d7f4384be206 # v3
            with:
               args: --check .

--- a/.github/workflows/prettify-code.yml
+++ b/.github/workflows/prettify-code.yml
@@ -10,7 +10,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
          - name: Checkout Repository
-           uses: actions/checkout@v4
+           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
          - name: Enforce Prettier
            uses: actionsx/prettier@v3

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,6 +13,6 @@ jobs:
       permissions:
          actions: read
          contents: write
-      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@v1
+      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@6f9de5deea0d6655168c8dd26e8849698f9a3809 # v1.0.2
       with:
          changelogPath: ./CHANGELOG.md

--- a/.github/workflows/tag-and-draft.yml
+++ b/.github/workflows/tag-and-draft.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
    tag-and-release:
-      uses: OliverMKing/javascript-release-workflow/.github/workflows/tag-and-release.yml@main
+      uses: OliverMKing/javascript-release-workflow/.github/workflows/tag-and-release.yml@c753e1545b144562237cd1177a95bab21a785cff # main

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
    build: # make sure build/ci works properly
       runs-on: ubuntu-latest
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
          - name: Run L0 tests.
            run: |


### PR DESCRIPTION
This pull request updates several GitHub Action workflows to use specific commit SHAs instead of version tags. This ensures that the workflows use a fixed version of the actions, avoiding potential security issues with future updates.

Updates to GitHub Action workflows:

* [`.github/workflows/defaultLabels.yml`](diffhunk://#diff-e386045ef5be03fdeeb15d9a642f5e25fd9fa1a46c218b074a557e860641a8aaL16-R16): Updated `actions/stale` to use commit SHA `5bef64f19d7facfb25b37b414482c7164d639639` instead of version `v9`. [[1]](diffhunk://#diff-e386045ef5be03fdeeb15d9a642f5e25fd9fa1a46c218b074a557e860641a8aaL16-R16) [[2]](diffhunk://#diff-e386045ef5be03fdeeb15d9a642f5e25fd9fa1a46c218b074a557e860641a8aaL27-R27)
* [`.github/workflows/integration-tests.yml`](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593L18-R18): Updated `actions/checkout` to use commit SHA `11bd71901bbe5b1630ceea73d27597364c9af683` instead of version `v4`.
* [`.github/workflows/prettify-code.yml`](diffhunk://#diff-cc8dc446bea329db280a1f3aae8a8b47599dd836db40212a3ccca07e88561031L13-R16): Updated `actions/checkout` to use commit SHA `11bd71901bbe5b1630ceea73d27597364c9af683` instead of version `v4`, and `actionsx/prettier` to use commit SHA `3d9f7c3fa44c9cb819e68292a328d7f4384be206` instead of version `v3`.
* [`.github/workflows/release-pr.yml`](diffhunk://#diff-6d2776058621d57e67ee850e7db85691f8747f8bfa43021c3eb0663e78c8f2e8L16-R16): Updated `Azure/action-release-workflows` to use commit SHA `6f9de5deea0d6655168c8dd26e8849698f9a3809` instead of version `v1`.
* [`.github/workflows/tag-and-draft.yml`](diffhunk://#diff-c35d92e54b4b154bbdce0b9d3f55a142486c5a11ccefec5bc6073d858feaf4a7L10-R10): Updated `OliverMKing/javascript-release-workflow` to use commit SHA `c753e1545b144562237cd1177a95bab21a785cff` instead of the `main` branch.
* [`.github/workflows/unit-tests.yml`](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3L16-R16): Updated `actions/checkout` to use commit SHA `11bd71901bbe5b1630ceea73d27597364c9af683` instead of version `v4`.

Noticed that for the repo is using a third party action step for prettier: "action**x**/prettier". Wanted to understand its usage vs the native prettier check.