### PR TITLE
chore: remove unnecessary prebuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
    },
    "main": "lib/index.js",
    "scripts": {
-      "prebuild": "npm i ncc",
       "build": "ncc build src/index.ts -o lib",
       "test": "jest",
       "test-coverage": "jest --coverage",


### PR DESCRIPTION
`@vercel/ncc` is already specified in dev dependencies, so `npm i` installs it. There's no need for a separate `npm i ncc`.

Running the prebuild script also adds a dependency, which is definitely not desired.
