### PR TITLE
ci(workflows): update helm version to v3.18.4 and add matrix for tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,11 +7,19 @@ on:
 jobs:
    trigger-integration-tests:
       name: Trigger Integration tests
-      runs-on: ubuntu-latest
+      strategy:
+         matrix:
+            os:
+               - ubuntu-latest
+               - ubuntu-24.04-arm
+               - macos-latest # arm
+               - macos-13 # x64
+         fail-fast: false
+      runs-on: ${{ matrix.os }}
       env:
-         HELM_3_8_0: 'v3.8.0'
-         HELM_3_7_2: 'v3.7.2'
-         HELM_NO_V: '3.5.0'
+         HELM_3_18_4: 'v3.18.4'
+         HELM_3_18_0: 'v3.18.0'
+         HELM_NO_V: '3.18.4'
          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       steps:
          - name: Check out repository
@@ -27,41 +35,41 @@ jobs:
          - name: Setup helm
            uses: ./
            with:
-              version: ${{ env.HELM_3_8_0 }}
-         - name: Validate helm 3.8.0
+              version: ${{ env.HELM_3_18_4 }}
+         - name: Validate helm 3.18.4
            run: |
-              if [[ $(helm version) != *$HELM_3_8_0* ]]; then
-                echo "HELM VERSION INCORRECT: HELM VERSION DOES NOT CONTAIN v3.8.0"
+              if [[ $(helm version) != *$HELM_3_18_4* ]]; then
+                echo "HELM VERSION INCORRECT: HELM VERSION DOES NOT CONTAIN v3.18.4"
                 echo "HELM VERSION OUTPUT: $(helm version)"
                 exit 1
               else
-                echo "HELM VERSION $HELM_3_8_0 INSTALLED SUCCESSFULLY"
+                echo "HELM VERSION $HELM_3_18_4 INSTALLED SUCCESSFULLY"
               fi
-         - name: Setup helm 3.7.2
+         - name: Setup helm 3.18.0
            uses: ./
            with:
-              version: ${{ env.HELM_3_7_2 }}
-         - name: Validate 3.7.2
+              version: ${{ env.HELM_3_18_0 }}
+         - name: Validate 3.18.0
            run: |
-              if [[ $(helm version) != *$HELM_3_7_2* ]]; then
-                echo "HELM VERSION INCORRECT: HELM VERSION DOES NOT CONTAIN v3.7.2"
+              if [[ $(helm version) != *$HELM_3_18_0* ]]; then
+                echo "HELM VERSION INCORRECT: HELM VERSION DOES NOT CONTAIN v3.18.0"
                 echo "HELM VERSION OUTPUT: $(helm version)"
                 exit 1
               else
-                echo "HELM VERSION $HELM_3_7_2 INSTALLED SUCCESSFULLY"
+                echo "HELM VERSION $HELM_3_18_0 INSTALLED SUCCESSFULLY"
               fi
-         - name: Setup helm 3.5.0 with no v in version
+         - name: Setup helm 3.18.4 with no v in version
            uses: ./
            with:
               version: ${{ env.HELM_NO_V }}
-         - name: Validate 3.5.0 without v in version
+         - name: Validate 3.18.4 without v in version
            run: |
               if [[ $(helm version) != *$HELM_NO_V* ]]; then
-                echo "HELM VERSION INCORRECT: HELM VERSION DOES NOT CONTAIN v3.5.0"
+                echo "HELM VERSION INCORRECT: HELM VERSION DOES NOT CONTAIN 3.18.4"
                 echo "HELM VERSION OUTPUT: $(helm version)"
                 exit 1
               else
-                echo "HELM VERSION $HELM_3_5_0 INSTALLED SUCCESSFULLY"
+                echo "HELM VERSION $HELM_NO_V INSTALLED SUCCESSFULLY"
               fi
          - name: Setup helm latest version
            uses: ./

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,17 @@ on: # rebuild any PRs and main branch changes
 
 jobs:
    build: # make sure build/ci works properly
-      runs-on: ubuntu-latest
+      strategy:
+         matrix:
+            os:
+               - ubuntu-latest
+               - ubuntu-24.04-arm
+               - windows-latest
+               - windows-11-arm
+               - macos-latest # arm
+               - macos-13 # x64
+         fail-fast: false
+      runs-on: ${{ matrix.os }}
       steps:
          - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -10,7 +10,7 @@ import * as toolCache from '@actions/tool-cache'
 import * as core from '@actions/core'
 
 const helmToolName = 'helm'
-export const stableHelmVersion = 'v3.18.3'
+export const stableHelmVersion = 'v3.18.4'
 
 export async function run() {
    let version = core.getInput('version', {required: true})


### PR DESCRIPTION
This pull request is based on https://github.com/Azure/setup-helm/pull/193 by @corneliusroemer and  updates the CI workflow to improve platform coverage and ensure the use of the latest stable Helm versions in both integration and unit tests. The changes also update the default Helm version in the codebase.

**CI Platform Coverage Improvements:**

* The `integration-tests.yml` and `unit-tests.yml` workflows now use a matrix strategy to run tests across multiple operating systems, including Ubuntu (x64 and ARM), macOS (x64 and ARM), and Windows (x64 and ARM), increasing test coverage and reliability across platforms. [[1]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593L10-R22) [[2]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3L14-R24)

**Helm Version Updates:**

* The integration test workflow updates Helm versions to `v3.18.4` and `v3.18.0`, replacing older versions (`v3.8.0`, `v3.7.2`, and `3.5.0`), ensuring tests use the most recent stable releases. Validation steps and environment variables have been updated accordingly. [[1]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593L10-R22) [[2]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593L30-R72)
* The default stable Helm version in `src/run.ts` is updated from `v3.18.3` to `v3.18.4`, ensuring the codebase references the latest release.