### PR TITLE
Update Helm version retrieval method in CI workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -80,12 +80,7 @@ jobs:
            env:
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
            run: |
-              HELM_LATEST=$(gh release list \
-                --repo helm/helm \
-                --exclude-drafts \
-                --exclude-pre-releases \
-                --json name,isLatest \
-                --jq '.[] | select(.isLatest)|.name' | awk '{print $2}')
+              HELM_LATEST=$(curl -s https://get.helm.sh/helm-latest-version)
 
               if [[ $(helm version) != *$HELM_LATEST* ]]; then
                 echo "HELM VERSION INCORRECT: HELM VERSION DOES NOT CONTAIN $HELM_LATEST"


### PR DESCRIPTION
Replaced gh command with curl to fetch latest Helm version.