### PR TITLE
fix: use chmod 755 instead of 777 for downloaded helm binary and folder

### DIFF
--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -288,11 +288,11 @@ describe('run.ts', () => {
       expect(toolCache.downloadTool).toHaveBeenCalledWith(
          'https://test.tld/helm-v4.0.0-windows-amd64.zip'
       )
-      expect(fs.chmodSync).toHaveBeenCalledWith('pathToTool', '777')
+      expect(fs.chmodSync).toHaveBeenCalledWith('pathToTool', '755')
       expect(toolCache.extractZip).toHaveBeenCalledWith('pathToTool')
       expect(fs.chmodSync).toHaveBeenCalledWith(
          path.join('pathToCachedDir', 'helm.exe'),
-         '777'
+         '755'
       )
    })
 
@@ -335,7 +335,7 @@ describe('run.ts', () => {
       expect(toolCache.find).toHaveBeenCalledWith('helm', 'v3.2.1')
       expect(fs.chmodSync).toHaveBeenCalledWith(
          path.join('pathToCachedDir', 'helm.exe'),
-         '777'
+         '755'
       )
    })
 
@@ -362,7 +362,7 @@ describe('run.ts', () => {
       expect(toolCache.downloadTool).toHaveBeenCalledWith(
          'https://test.tld/helm-v3.2.1-windows-amd64.zip'
       )
-      expect(fs.chmodSync).toHaveBeenCalledWith('pathToTool', '777')
+      expect(fs.chmodSync).toHaveBeenCalledWith('pathToTool', '755')
       expect(toolCache.extractZip).toHaveBeenCalledWith('pathToTool')
    })
 })

--- a/src/run.ts
+++ b/src/run.ts
@@ -105,7 +105,7 @@ export async function downloadHelm(
          )
       }
 
-      fs.chmodSync(helmDownloadPath, '777')
+      fs.chmodSync(helmDownloadPath, '755')
       const extractedPath =
          getPlatform() === 'windows'
             ? await toolCache.extractZip(helmDownloadPath)
@@ -125,12 +125,12 @@ export async function downloadHelm(
       )
    }
 
-   fs.chmodSync(helmpath, '777')
+   fs.chmodSync(helmpath, '755')
    return helmpath
 }
 
 export function findHelm(rootFolder: string): string {
-   fs.chmodSync(rootFolder, '777')
+   fs.chmodSync(rootFolder, '755')
    let filelist: string[] = []
    walkSync(rootFolder, filelist, helmToolName + getExecutableExtension())
    if (!filelist || filelist.length == 0) {


### PR DESCRIPTION
World-writable permissions allow other processes on shared runners to replace the helm binary or inject files between download and execution.