### PR TITLE
chore(release): v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Change Log
 
+## [5.0.1] - 2026-06-23
+
+### Fixed
+
+- #271 [Fix TypeScript 6.0 compatibility errors in run.ts](https://github.com/Azure/setup-helm/pull/271)
+- #278 [fix: use chmod 755 instead of 777 for downloaded helm binary and folder](https://github.com/Azure/setup-helm/pull/278)
+
+### Changed
+
+- #286 [Bump actions/checkout from 6.0.3 to 7.0.0 in /.github/workflows in the actions group](https://github.com/Azure/setup-helm/pull/286)
+- #285 [Bump the actions group with 2 updates](https://github.com/Azure/setup-helm/pull/285)
+- #284 [Bump undici](https://github.com/Azure/setup-helm/pull/284)
+- #283 [Bump the actions group with 5 updates](https://github.com/Azure/setup-helm/pull/283)
+- #280 [Bump actions/checkout from 6.0.2 to 6.0.3 in /.github/workflows in the actions group](https://github.com/Azure/setup-helm/pull/280)
+- #279 [Bump the actions group with 2 updates](https://github.com/Azure/setup-helm/pull/279)
+- #277 [Bump vitest from 4.1.7 to 4.1.8 in the actions group](https://github.com/Azure/setup-helm/pull/277)
+- #276 [chore: remove deprecated OliverMKing release workflow, pin to SHA](https://github.com/Azure/setup-helm/pull/276)
+- #275 [Bump actions/stale from 10.2.0 to 10.3.0 in /.github/workflows in the actions group](https://github.com/Azure/setup-helm/pull/275)
+- #274 [Bump the actions group with 3 updates](https://github.com/Azure/setup-helm/pull/274)
+- #273 [Bump the actions group with 2 updates](https://github.com/Azure/setup-helm/pull/273)
+- #269 [Bump the actions group across 1 directory with 7 updates](https://github.com/Azure/setup-helm/pull/269)
+- #268 [Bump vite from 8.0.0 to 8.0.5](https://github.com/Azure/setup-helm/pull/268)
+- #260 [Migrate to ESM with esbuild/vitest and upgrade to node24 (v5.0.0)](https://github.com/Azure/setup-helm/pull/260)
+
 ## [5.0.0] - 2026-03-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install a specific version of helm binary on the runner.
 Acceptable values are latest or any semantic version string like v3.5.0 Use this action in workflow to define which version of helm will be used. v2+ of this action only support Helm3.
 
 ```yaml
-- uses: azure/setup-helm@v5.0.0
+- uses: azure/setup-helm@v5
   with:
      version: '<version>' # default is latest (stable)
   id: install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "setuphelm",
-   "version": "5.0.0",
+   "version": "5.0.1",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "setuphelm",
-         "version": "5.0.0",
+         "version": "5.0.1",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "setuphelm",
-   "version": "5.0.0",
+   "version": "5.0.1",
    "private": true,
    "description": "Setup helm",
    "author": "Anumita Shenoy",


### PR DESCRIPTION

## Summary

Release PR for **v5.0.1** — patch version bump covering all changes since v5.0.0.

## Highlights

### Fixed
- Fix TypeScript 6.0 compatibility errors in `run.ts` (#271)
- Use `chmod 755` instead of `777` for the downloaded helm binary and folder (#278)

### Changed
- Migrate to ESM with esbuild/vitest and upgrade to node24 (#260)
- Remove deprecated OliverMKing release workflow, pin actions to SHA (#276)
- Numerous npm dependency and GitHub Actions bumps (grouped in CHANGELOG)

## Version bumps
- `package.json`: 5.0.0 → 5.0.1
- `package-lock.json`: 5.0.0 → 5.0.1

See `CHANGELOG.md` for the full list.