### PR TITLE
Fix URL resolution for subpath base URLs in Helm downloads

### DIFF
--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -140,6 +140,34 @@ describe('run.ts', () => {
       expect(os.platform).toHaveBeenCalled()
    })
 
+   test('getHelmDownloadURL() - preserve a subpath base URL without a trailing slash', () => {
+      vi.mocked(os.platform).mockReturnValue('linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+
+      const expected =
+         'https://mirror.example/kubernetes/helm/helm-v3.8.0-linux-amd64.tar.gz'
+      expect(
+         run.getHelmDownloadURL(
+            'https://mirror.example/kubernetes/helm',
+            'v3.8.0'
+         )
+      ).toBe(expected)
+   })
+
+   test('getHelmDownloadURL() - preserve a subpath base URL with a trailing slash', () => {
+      vi.mocked(os.platform).mockReturnValue('linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+
+      const expected =
+         'https://mirror.example/kubernetes/helm/helm-v3.8.0-linux-amd64.tar.gz'
+      expect(
+         run.getHelmDownloadURL(
+            'https://mirror.example/kubernetes/helm/',
+            'v3.8.0'
+         )
+      ).toBe(expected)
+   })
+
    test('getLatestHelmVersion() - return the latest version of HELM', async () => {
       const res = {
          status: 200,

--- a/src/run.ts
+++ b/src/run.ts
@@ -139,7 +139,11 @@ export function getExecutableExtension(): string {
 
 export function getHelmDownloadURL(baseURL: string, version: string): string {
    const urlPath = `helm-${version}-${getPlatform()}-${getArch()}.${getArchiveExtension()}`
-   const url = new URL(urlPath, baseURL)
+   // Ensure the base ends with '/' so a subpath mirror (e.g.
+   // 'https://example/kubernetes/helm') is preserved; otherwise URL resolution
+   // replaces the last path segment and points at the wrong location.
+   const base = baseURL.endsWith('/') ? baseURL : `${baseURL}/`
+   const url = new URL(urlPath, base)
    return url.toString()
 }
 


### PR DESCRIPTION
This pull request addresses an issue with constructing Helm download URLs when a custom base URL contains a subpath, ensuring the correct path is preserved regardless of whether the base URL ends with a trailing slash. It also adds new tests to verify this behavior.

**Bug Fixes and Improvements:**

* Ensured that `getHelmDownloadURL` correctly handles base URLs with or without a trailing slash, preserving subpath segments and preventing incorrect URL resolution. (`src/run.ts`)

**Testing Enhancements:**

* Added tests to verify that `getHelmDownloadURL` preserves subpath base URLs both with and without a trailing slash. (`src/run.test.ts`)Ensure downloadBaseURL ends with '/' before URL resolution so a subpath mirror (e.g. https://example/kubernetes/helm) is preserved instead of having its last path segment replaced. Fixes downloads for all subpath mirrors.