### PR TITLE
fix: retry latest version lookup and add latest-fallback opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ helm 3.18.4
 If both `version` and `version-file` are set, an explicitly requested `version` takes precedence and `version-file` is ignored (a warning is emitted). Because `version` defaults to `latest`, `version-file` is only ignored when you set `version` to a specific value other than `latest`; if `version` is left at its default, the version from `version-file` is used.
 
 > [!NOTE]
-> If something goes wrong with fetching the latest version the action will use the hardcoded default version (currently v3.18.4). If you rely on a certain version higher than the default, you should explicitly use that version instead of latest.
+> If fetching the latest version fails after a few retries, the action will use the hardcoded default version (currently v3.18.4) and emit a warning. If you rely on a certain version higher than the default, you should explicitly use that version instead of latest. To make the step fail instead of installing the default version, set `latest-fallback` to `'false'`:
+>
+> ```yaml
+> - uses: azure/setup-helm@v5
+>   with:
+>      version: 'latest'
+>      latest-fallback: 'false'
+> ```
 
 The cached helm binary path is prepended to the PATH environment variable as well as stored in the helm-path output variable.
 Refer to the action metadata file for details about all the inputs https://github.com/Azure/setup-helm/blob/master/action.yml

--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ helm 3.18.4
 If both `version` and `version-file` are set, an explicitly requested `version` takes precedence and `version-file` is ignored (a warning is emitted). Because `version` defaults to `latest`, `version-file` is only ignored when you set `version` to a specific value other than `latest`; if `version` is left at its default, the version from `version-file` is used.
 
 > [!NOTE]
-> If fetching the latest version fails after a few retries, the action will use the hardcoded default version (currently v3.18.4) and emit a warning. If you rely on a certain version higher than the default, you should explicitly use that version instead of latest. To make the step fail instead of installing the default version, set `latest-fallback` to `'false'`:
+> If fetching the latest version fails, the action retries a few times and then fails the step with the underlying error. It does not install the hardcoded default version (currently v3.18.4), because that default can be a major version behind what `latest` resolves to. To install the default version instead of failing, set `latest-fallback` to `'true'`:
 >
 > ```yaml
 > - uses: azure/setup-helm@v5
 >   with:
 >      version: 'latest'
->      latest-fallback: 'false'
+>      latest-fallback: 'true'
 > ```
+>
+> If you rely on a certain version, you should explicitly request that version instead of `latest`.
 
 The cached helm binary path is prepended to the PATH environment variable as well as stored in the helm-path output variable.
 Refer to the action metadata file for details about all the inputs https://github.com/Azure/setup-helm/blob/master/action.yml

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,9 @@ inputs:
       required: false
       default: 'https://get.helm.sh'
    latest-fallback:
-      description: "When 'version' is 'latest' and the latest version cannot be determined, install the built-in default version instead of failing. Set to 'false' to fail the step instead."
+      description: "When 'version' is 'latest' and the latest version cannot be determined after retrying, install the built-in default version instead of failing. Off by default, because the built-in default can be a major version behind what 'latest' resolves to."
       required: false
-      default: 'true'
+      default: 'false'
 outputs:
    helm-path:
       description: 'Path to the cached helm binary'

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
       description: 'Set the download base URL'
       required: false
       default: 'https://get.helm.sh'
+   latest-fallback:
+      description: "When 'version' is 'latest' and the latest version cannot be determined, install the built-in default version instead of failing. Set to 'false' to fail the step instead."
+      required: false
+      default: 'true'
 outputs:
    helm-path:
       description: 'Path to the cached helm binary'

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -66,6 +66,7 @@ describe('run.ts', () => {
    // Cleanup mocks after each test to ensure that subsequent tests are not affected by the mocks.
    afterEach(() => {
       vi.restoreAllMocks()
+      vi.useRealTimers()
    })
 
    test('getExecutableExtension() - return .exe when os is Windows', () => {
@@ -168,21 +169,70 @@ describe('run.ts', () => {
       ).toBe(expected)
    })
 
-   test('getLatestHelmVersion() - return the latest version of HELM', async () => {
-      const res = {
+   const latestVersionResponse = (version: string) =>
+      ({
+         ok: true,
          status: 200,
-         text: async () => 'v9.99.999'
-      } as Response
-      vi.spyOn(globalThis, 'fetch').mockResolvedValue(res)
+         text: async () => version
+      }) as Response
+
+   // Runs a getLatestHelmVersion() call under fake timers so the retry
+   // backoff does not slow the test down.
+   const getLatestHelmVersionWithoutDelay = async (
+      fallbackToDefault?: boolean
+   ) => {
+      vi.useFakeTimers()
+      const pending = run.getLatestHelmVersion(fallbackToDefault)
+      // Attach a no-op handler so a rejection is not reported as unhandled
+      // while the timers are being advanced; the caller still awaits it.
+      pending.catch(() => {})
+      await vi.runAllTimersAsync()
+      return pending
+   }
+
+   test('getLatestHelmVersion() - return the latest version of HELM', async () => {
+      const fetchSpy = vi
+         .spyOn(globalThis, 'fetch')
+         .mockResolvedValue(latestVersionResponse('v9.99.999'))
       expect(await run.getLatestHelmVersion()).toBe('v9.99.999')
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
    })
 
-   test('getLatestHelmVersion() - return the stable version of HELM when simulating a network error', async () => {
+   test('getLatestHelmVersion() - retry a transient failure and return the latest version', async () => {
+      const fetchSpy = vi
+         .spyOn(globalThis, 'fetch')
+         .mockRejectedValueOnce(new Error('Network Error'))
+         .mockResolvedValueOnce({ok: false, status: 503} as Response)
+         .mockResolvedValueOnce(latestVersionResponse('v9.99.999'))
+      expect(await getLatestHelmVersionWithoutDelay()).toBe('v9.99.999')
+      expect(fetchSpy).toHaveBeenCalledTimes(3)
+      expect(core.warning).not.toHaveBeenCalled()
+   })
+
+   test('getLatestHelmVersion() - return the stable version of HELM when every attempt fails', async () => {
       const errorMessage: string = 'Network Error'
-      vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
-         new Error(errorMessage)
+      const fetchSpy = vi
+         .spyOn(globalThis, 'fetch')
+         .mockRejectedValue(new Error(errorMessage))
+      expect(await getLatestHelmVersionWithoutDelay()).toBe(
+         run.stableHelmVersion
       )
-      expect(await run.getLatestHelmVersion()).toBe(run.stableHelmVersion)
+      expect(fetchSpy).toHaveBeenCalledTimes(3)
+      expect(core.warning).toHaveBeenCalledWith(
+         expect.stringContaining(errorMessage)
+      )
+   })
+
+   test('getLatestHelmVersion() - throw when every attempt fails and the fallback is disabled', async () => {
+      const errorMessage: string = 'Network Error'
+      const fetchSpy = vi
+         .spyOn(globalThis, 'fetch')
+         .mockRejectedValue(new Error(errorMessage))
+      await expect(getLatestHelmVersionWithoutDelay(false)).rejects.toThrow(
+         `Unable to determine the latest Helm version: ${errorMessage}`
+      )
+      expect(fetchSpy).toHaveBeenCalledTimes(3)
+      expect(core.warning).not.toHaveBeenCalled()
    })
 
    test('getValidVersion() - return version with v prepended', () => {
@@ -299,11 +349,16 @@ describe('run.ts', () => {
       } as fs.Stats)
    }
 
-   const inputs = (version: string, versionFile: string) =>
+   const inputs = (
+      version: string,
+      versionFile: string,
+      latestFallback: string = 'true'
+   ) =>
       vi.mocked(core.getInput).mockImplementation((name: string) => {
          if (name === 'version') return version
          if (name === 'version-file') return versionFile
          if (name === 'downloadBaseURL') return downloadBaseURL
+         if (name === 'latest-fallback') return latestFallback
          return ''
       })
 
@@ -514,6 +569,42 @@ describe('run.ts', () => {
       await expect(
          run.resolveLatestPatchVersion(downloadBaseURL, '3.14')
       ).rejects.toThrow('exceeded 100 probes')
+   })
+
+   test('run() - install the default version when latest cannot be determined', async () => {
+      stubDownloadChain()
+      inputs('latest', '')
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+         new Error('Network Error')
+      )
+      vi.useFakeTimers()
+
+      const pending = run.run()
+      await vi.runAllTimersAsync()
+      await pending
+
+      expect(core.warning).toHaveBeenCalledWith(
+         expect.stringContaining(run.stableHelmVersion)
+      )
+      expect(toolCache.find).toHaveBeenCalledWith('helm', run.stableHelmVersion)
+   })
+
+   test('run() - fail when latest cannot be determined and latest-fallback is false', async () => {
+      stubDownloadChain()
+      inputs('latest', '', 'false')
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+         new Error('Network Error')
+      )
+      vi.useFakeTimers()
+
+      const pending = run.run()
+      pending.catch(() => {})
+      await vi.runAllTimersAsync()
+      await expect(pending).rejects.toThrow(
+         'Unable to determine the latest Helm version: Network Error'
+      )
+
+      expect(toolCache.find).not.toHaveBeenCalled()
    })
 
    test('run() - resolve the latest patch for a major.minor version input', async () => {

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -209,12 +209,12 @@ describe('run.ts', () => {
       expect(core.warning).not.toHaveBeenCalled()
    })
 
-   test('getLatestHelmVersion() - return the stable version of HELM when every attempt fails', async () => {
+   test('getLatestHelmVersion() - return the stable version of HELM when every attempt fails and the fallback is enabled', async () => {
       const errorMessage: string = 'Network Error'
       const fetchSpy = vi
          .spyOn(globalThis, 'fetch')
          .mockRejectedValue(new Error(errorMessage))
-      expect(await getLatestHelmVersionWithoutDelay()).toBe(
+      expect(await getLatestHelmVersionWithoutDelay(true)).toBe(
          run.stableHelmVersion
       )
       expect(fetchSpy).toHaveBeenCalledTimes(3)
@@ -223,12 +223,12 @@ describe('run.ts', () => {
       )
    })
 
-   test('getLatestHelmVersion() - throw when every attempt fails and the fallback is disabled', async () => {
+   test('getLatestHelmVersion() - throw when every attempt fails', async () => {
       const errorMessage: string = 'Network Error'
       const fetchSpy = vi
          .spyOn(globalThis, 'fetch')
          .mockRejectedValue(new Error(errorMessage))
-      await expect(getLatestHelmVersionWithoutDelay(false)).rejects.toThrow(
+      await expect(getLatestHelmVersionWithoutDelay()).rejects.toThrow(
          `Unable to determine the latest Helm version: ${errorMessage}`
       )
       expect(fetchSpy).toHaveBeenCalledTimes(3)
@@ -352,7 +352,7 @@ describe('run.ts', () => {
    const inputs = (
       version: string,
       versionFile: string,
-      latestFallback: string = 'true'
+      latestFallback: string = 'false'
    ) =>
       vi.mocked(core.getInput).mockImplementation((name: string) => {
          if (name === 'version') return version
@@ -571,27 +571,9 @@ describe('run.ts', () => {
       ).rejects.toThrow('exceeded 100 probes')
    })
 
-   test('run() - install the default version when latest cannot be determined', async () => {
+   test('run() - fail when latest cannot be determined', async () => {
       stubDownloadChain()
       inputs('latest', '')
-      vi.spyOn(globalThis, 'fetch').mockRejectedValue(
-         new Error('Network Error')
-      )
-      vi.useFakeTimers()
-
-      const pending = run.run()
-      await vi.runAllTimersAsync()
-      await pending
-
-      expect(core.warning).toHaveBeenCalledWith(
-         expect.stringContaining(run.stableHelmVersion)
-      )
-      expect(toolCache.find).toHaveBeenCalledWith('helm', run.stableHelmVersion)
-   })
-
-   test('run() - fail when latest cannot be determined and latest-fallback is false', async () => {
-      stubDownloadChain()
-      inputs('latest', '', 'false')
       vi.spyOn(globalThis, 'fetch').mockRejectedValue(
          new Error('Network Error')
       )
@@ -605,6 +587,24 @@ describe('run.ts', () => {
       )
 
       expect(toolCache.find).not.toHaveBeenCalled()
+   })
+
+   test('run() - install the default version when latest-fallback is true', async () => {
+      stubDownloadChain()
+      inputs('latest', '', 'true')
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+         new Error('Network Error')
+      )
+      vi.useFakeTimers()
+
+      const pending = run.run()
+      await vi.runAllTimersAsync()
+      await pending
+
+      expect(core.warning).toHaveBeenCalledWith(
+         expect.stringContaining(run.stableHelmVersion)
+      )
+      expect(toolCache.find).toHaveBeenCalledWith('helm', run.stableHelmVersion)
    })
 
    test('run() - resolve the latest patch for a major.minor version input', async () => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -34,7 +34,9 @@ export async function run() {
    const downloadBaseURL = core.getInput('downloadBaseURL', {required: false})
 
    if (version.toLocaleLowerCase() === 'latest') {
-      version = await getLatestHelmVersion()
+      const fallbackToDefault =
+         core.getInput('latest-fallback').toLowerCase() !== 'false'
+      version = await getLatestHelmVersion(fallbackToDefault)
    } else if (isMajorMinorShaped(version)) {
       version = await resolveLatestPatchVersion(downloadBaseURL, version)
       core.info(`Resolved latest patch Helm version to '${version}'`)
@@ -122,15 +124,57 @@ export function parseToolVersions(content: string): string {
    return ''
 }
 
-// Gets the latest helm version or returns a default stable if getting latest fails
-export async function getLatestHelmVersion(): Promise<string> {
+const latestVersionURL = 'https://get.helm.sh/helm-latest-version'
+
+// Number of attempts made to fetch the latest version before giving up, and
+// the wait before the second attempt (each further wait doubles the previous).
+const latestVersionAttempts = 3
+const latestVersionRetryDelayMs = 1000
+
+// Fetches the latest helm version. A failed request or a non-2xx response is
+// retried with a short backoff, so a single transient failure does not decide
+// the outcome. Throws the last error once every attempt has failed.
+export async function fetchLatestHelmVersion(): Promise<string> {
+   let delayMs = latestVersionRetryDelayMs
+   for (let attempt = 1; ; attempt++) {
+      try {
+         const response = await fetch(latestVersionURL)
+         if (!response.ok) {
+            throw new Error(
+               `Unexpected HTTP ${response.status} from ${latestVersionURL}`
+            )
+         }
+         return (await response.text()).trim()
+      } catch (err) {
+         if (attempt >= latestVersionAttempts) {
+            throw err
+         }
+         core.info(
+            `Attempt ${attempt} of ${latestVersionAttempts} to fetch the latest Helm version failed: ${err instanceof Error ? err.message : String(err)}. Retrying in ${delayMs}ms`
+         )
+         await new Promise((resolve) => setTimeout(resolve, delayMs))
+         delayMs *= 2
+      }
+   }
+}
+
+// Gets the latest helm version. When it cannot be determined, either falls
+// back to the built-in default version (with a warning) or throws, depending
+// on fallbackToDefault.
+export async function getLatestHelmVersion(
+   fallbackToDefault = true
+): Promise<string> {
    try {
-      const response = await fetch('https://get.helm.sh/helm-latest-version')
-      const release = (await response.text()).trim()
-      return release
+      return await fetchLatestHelmVersion()
    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      if (!fallbackToDefault) {
+         throw new Error(
+            `Unable to determine the latest Helm version: ${message}. Set 'latest-fallback' to 'true' to install the default version ${stableHelmVersion} instead, or request a specific version`
+         )
+      }
       core.warning(
-         `Error while fetching latest Helm release: ${err instanceof Error ? err.message : String(err)}. Using default version ${stableHelmVersion}`
+         `Error while fetching latest Helm release: ${message}. Using default version ${stableHelmVersion}`
       )
       return stableHelmVersion
    }

--- a/src/run.ts
+++ b/src/run.ts
@@ -35,7 +35,7 @@ export async function run() {
 
    if (version.toLocaleLowerCase() === 'latest') {
       const fallbackToDefault =
-         core.getInput('latest-fallback').toLowerCase() !== 'false'
+         core.getInput('latest-fallback').toLowerCase() === 'true'
       version = await getLatestHelmVersion(fallbackToDefault)
    } else if (isMajorMinorShaped(version)) {
       version = await resolveLatestPatchVersion(downloadBaseURL, version)
@@ -158,11 +158,12 @@ export async function fetchLatestHelmVersion(): Promise<string> {
    }
 }
 
-// Gets the latest helm version. When it cannot be determined, either falls
-// back to the built-in default version (with a warning) or throws, depending
-// on fallbackToDefault.
+// Gets the latest helm version. When it cannot be determined, throws, or
+// falls back to the built-in default version with a warning when
+// fallbackToDefault is set. The default version can be a major behind what
+// 'latest' resolves to, so falling back to it is opt-in.
 export async function getLatestHelmVersion(
-   fallbackToDefault = true
+   fallbackToDefault = false
 ): Promise<string> {
    try {
       return await fetchLatestHelmVersion()


### PR DESCRIPTION
## What happens today

When `version` is `latest` (the default), `getLatestHelmVersion` makes a single request to `https://get.helm.sh/helm-latest-version`. If that one request fails for any reason, the action logs a warning and installs the hard-coded `stableHelmVersion` (`v3.18.4`). The step stays green.

That URL now returns `v4.3.0`, so the fallback moves a job back an entire major version on a single transient network failure. The run then fails later on something that does not look related. In our case a deploy died on `Error: unknown flag: --rollback-on-failure` several steps after the silent downgrade, and it took a while to trace it back to this step.

The same file already takes the opposite position for the major.minor path. The comment on `helmPatchExists` says: "Any other status (403/405/429/5xx, ...) and genuine network errors are thrown, so transient failures, rate-limiting, or a host that disallows HEAD are never mistaken for a missing patch." Only the `latest` path guesses, and it guesses across a major.

This is the bug reported in #187 (closed after the reporter found the fallback documented in the README, with the unanswered request "It should at the very least be possible to opt out of the fallback"). The same symptom was reported in #136, #219, #221 and #226. #188 is about the constant going stale, which this PR does not change.

## What this PR does

1. **Retries the lookup.** `fetchLatestHelmVersion` makes up to 3 attempts with a 1 s, then 2 s wait between them. A non-2xx response is treated as a failure instead of installing the response body as a version. A single transient failure no longer decides the outcome.
2. **Stops falling back across a major by default.** A new `latest-fallback` input controls what happens once the retries are exhausted. It defaults to `'false'`: the step fails with the underlying error. Setting it to `'true'` restores today's behavior, installing `stableHelmVersion` with the same warning as before.

## About that default

This is the one judgement call in the PR, so it is worth stating plainly rather than burying: it changes what happens in the failure path, and a workflow that would previously have gone green on a Helm 3 install will now fail instead.

The reasoning for `'false'`:

- The retries make the fallback path rare. It is reached only when three attempts spread over three seconds all fail, which is a different situation from the single-request failure that reaches it today.
- When it is reached, the outcome today is not "an older Helm". It is "a Helm from the wrong major, installed silently, in a job whose flags belong to the other major". Failing at this step names the problem; installing the wrong major hides it until something further down breaks.
- A step that fails is re-runnable. A step that silently installed the wrong tool costs someone an afternoon.

If you would rather not change the default in a minor release, I am happy to flip it to `'true'` here and leave `'false'` for a future major, or to drop the input entirely and keep only the retries. The retry part stands on its own and is the piece that fixes the reported incidents. Say which you prefer and I will push the change.

Out of scope: changing `stableHelmVersion` to a Helm 4 default. That would change what v3 users get when the fallback applies and belongs with #188 and #241.

## Changes

- `src/run.ts`: `fetchLatestHelmVersion` with retries; `getLatestHelmVersion(fallbackToDefault = false)`; `run()` reads `latest-fallback`.
- `src/run.test.ts`: tests for retry-then-succeed, every attempt failing (throws), every attempt failing with the fallback enabled, and two `run()` cases for the input. The retry backoff runs under fake timers so the suite stays fast.
- `action.yml`: `latest-fallback` input, default `'false'`.
- `README.md`: the note about the fallback describes the retries and the new default.

`npm test` (57 passing), `npm run typecheck` and `npm run format-check` pass locally. `lib/` is not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
